### PR TITLE
Support timeout and inbox prefix in request reply

### DIFF
--- a/frontend/docs/entities/connection/def/connection.md
+++ b/frontend/docs/entities/connection/def/connection.md
@@ -9,6 +9,7 @@ Connection {
 	id?: string
 	name: string
 	hosts: string[]
+	inboxPrefix: string
 	subscriptions: Subscription[]
 	auth: Auth[]
 	tls_auth: TLSAuth

--- a/frontend/docs/entities/request_response/request_response.md
+++ b/frontend/docs/entities/request_response/request_response.md
@@ -18,7 +18,7 @@ POST /api/connection/:connection_id/request
     "subject": string,	// request subject
     "payload": string,  // base64 encoded request payload
     "headers": {[key: string] : string[]},
-    "timeout": int // timeout in ms 
+    "timeout": int // timeout in ns
 }
 ```
 

--- a/frontend/src/api/messages.ts
+++ b/frontend/src/api/messages.ts
@@ -34,11 +34,11 @@ function subscriptionUpdate(cnnId: string, subscriptions: Subscription[], opt?: 
 /** SYNC
  * https://github.com/nats-nui/nui/blob/main/frontend/docs/entities/request_response/request_response.md
  */
-async function sync(cnnId: string, subject: string, payload: string, headersArray: [string, string][], timeout: number = 2000, opt: CallOptions = {}): Promise<SyncResp> {
+async function sync(cnnId: string, subject: string, payload: string, headersArray: [string, string][], timeoutMs: number = 2000, opt: CallOptions = {}): Promise<SyncResp> {
 	const data = camelToSnake({
 		subject,
 		payload: btoa(payload),
-		timeout
+		timeout_ms: timeoutMs
 	})
 	// like publish, also here the auto conversion to snake case is disabled
 	data.headers = toDic(headersArray)

--- a/frontend/src/components/stacks/connections/detail/Form.tsx
+++ b/frontend/src/components/stacks/connections/detail/Form.tsx
@@ -4,7 +4,7 @@ import { Auth, EDIT_STATE } from "@/types"
 import { useStore } from "@priolo/jon"
 import { FunctionComponent } from "react"
 import AuthForm from "./AuthForm"
-import { EditList, EditStringRow, IconToggle, ListObjects, TextInput, TitleAccordion } from "@priolo/jack"
+import {EditList, EditStringRow, IconToggle, ListObjects, TextInput, TitleAccordion, TooltipWrapCmp} from "@priolo/jack"
 
 
 
@@ -30,6 +30,9 @@ const ConnectionDetailForm: FunctionComponent<Props> = ({
     }
     const handleHostsChange = (hosts: string[]) => {
         cnnDetailSo.setConnection({ ...cnnDetailSa.connection, hosts })
+    }
+    const handleInboxPrefixChange = (inboxPrefix: string) => {
+        cnnDetailSo.setConnection({ ...cnnDetailSa.inboxPrefix, inboxPrefix })
     }
     const handleAuthChange = (auth: Auth, index: number) => {
         if (!auth) return
@@ -163,6 +166,19 @@ const ConnectionDetailForm: FunctionComponent<Props> = ({
                     readOnly={inRead}
                 />
             </div>
+        </TitleAccordion>
+        <TitleAccordion title="ADVANCED">
+            <div className="jack-lbl-prop lbl-info-container">INBOX PREFIX
+                <TooltipWrapCmp className="lbl-info" children="?"
+                                content="The prefix of subject used to receive responses in req /reply"
+                />
+            </div>
+            <TextInput autoFocus
+                       value={connection.inboxPrefix}
+                       onChange={handleInboxPrefixChange}
+                       placeholder="eg. _INBOX.>"
+                       readOnly={inRead}
+            />
         </TitleAccordion>
     </div>
 }

--- a/frontend/src/components/stacks/streams/detail/cmp/EditSourceCmp.tsx
+++ b/frontend/src/components/stacks/streams/detail/cmp/EditSourceCmp.tsx
@@ -144,7 +144,7 @@ const EditSourceCmp: FunctionComponent<Props> = ({
 				style={{ marginTop: 5 }}
 				items={source.subjectTransforms}
 				onItemsChange={handleSubjectTransformsChange}
-				placeholder="ex. orders.* or telemetry.>"
+				placeholder="eg. orders.* or telemetry.>"
 				readOnly={readOnly}
 				onNewItem={() => ({ src: "", dest: "" })}
 				fnIsVoid={i => !(i?.src.trim().length > 0) || !(i?.dest.trim().length > 0)}

--- a/frontend/src/components/stacks/sync/OptionsDialog.tsx
+++ b/frontend/src/components/stacks/sync/OptionsDialog.tsx
@@ -1,0 +1,56 @@
+import {Dialog} from "@priolo/jack"
+import {useStore} from "@priolo/jon"
+import {FunctionComponent} from "react"
+import {SyncState, SyncStore} from "@/stores/stacks/sync";
+import MaxTimeCmp, {TIME} from "@/components/input/MaxTimeCmp.tsx";
+
+
+interface Props {
+    store?: SyncStore
+}
+
+const OptionsDialog: FunctionComponent<Props> = ({
+                                                     store: syncSo,
+                                                 }) => {
+
+    // STORE
+    const syncSa = useStore(syncSo) as SyncState
+
+    // HOOKs
+
+    // HANDLER
+    const handleTimeoutChange = (timeoutMs) => {
+        syncSo.setTimeoutMs(timeoutMs)
+    }
+    const handleOptionsClose = () => {
+        syncSo.setOptionsOpen(false)
+    }
+
+    // RENDER
+
+    return <Dialog
+        open={syncSa.optionsOpen}
+        title="TIMEOUT"
+        width={150}
+        store={syncSo}
+        noCloseOnClickParent={true}
+        onClose={handleOptionsClose}
+    >
+        <div className="lyt-v">
+            <div className="jack-lbl-prop">TIMEOUT</div>
+            <MaxTimeCmp store={syncSo}
+                        label="TIMEOUT"
+                        value={syncSa.timeoutMs}
+                        desiredDefault={0}
+                        initDefault={1}
+                        inputUnit={TIME.MS}
+                        outputUnit={TIME.MS}
+                        onChange={handleTimeoutChange}
+            />
+        </div>
+
+
+    </Dialog>
+}
+
+export default OptionsDialog

--- a/frontend/src/components/stacks/sync/View.tsx
+++ b/frontend/src/components/stacks/sync/View.tsx
@@ -5,15 +5,16 @@ import HeadersCmp from "@/components/stacks/message/HeadersCmp.tsx"
 import ArrowRightIcon from "@/icons/ArrowRightIcon"
 import FormatIcon from "@/icons/FormatIcon"
 import SendIcon from "@/icons/SendIcon"
-import { SyncStore } from "@/stores/stacks/sync"
+import sync, { SyncStore } from "@/stores/stacks/sync"
 import { LOAD_STATE } from "@/stores/stacks/utils"
 import { useStore } from "@priolo/jon"
-import { FunctionComponent, useRef } from "react"
+import React, { FunctionComponent, useRef } from "react"
 import SyncIcon from "../../../icons/SyncIcon"
 import EditMetadataRow from "../../rows/EditMetadataRow"
 import clsCard from "../CardCyanDef.module.css"
 import cls from "./View.module.css"
 import { Button, CircularLoadingCmp, EditList, FloatButton, IconButton, TextInput, TitleAccordion, TooltipWrapCmp } from "@priolo/jack"
+import OptionsDialog from "@/components/stacks/sync/OptionsDialog.tsx";
 
 
 
@@ -40,6 +41,10 @@ const SyncView: FunctionComponent<Props> = ({
 		refSender.current?.format()
 		// timeout altrimenti non lo formatta se formatta il precedente!!!
 		setTimeout(refReceiver.current?.format, 300)
+	}
+	const handleOptionsClick = (e: React.MouseEvent, select?: boolean) => {
+		if (select) return
+		syncSo.setOptionsOpen(!select)
 	}
 	const handleMessageClick = (txt: string) => syncSo.openMessageDetail({
 		payload: txt,
@@ -71,6 +76,12 @@ const SyncView: FunctionComponent<Props> = ({
 				select={syncSa.formatsOpen}
 				children={syncSa.format?.toUpperCase() ?? ""}
 				onClick={() => syncSo.setFormatsOpen(true)}
+			/>
+			<div style={{ height: "20px", width: "2px", backgroundColor: "rgba(255,255,255,.3)" }} />
+			<Button
+				select={syncSa.formatsOpen}
+				children={"OPTIONS"}
+				onClick={() => syncSo.setOptionsOpen(true)}
 			/>
 			<div style={{ height: "20px", width: "2px", backgroundColor: "rgba(255,255,255,.3)" }} />
 			<Button
@@ -158,7 +169,7 @@ const SyncView: FunctionComponent<Props> = ({
 		</div>
 
 		<FormatDialog editMode store={syncSo} />
-
+		<OptionsDialog store={syncSo}/>
 	</FrameworkCard>
 }
 

--- a/frontend/src/mocks/data/connections.ts
+++ b/frontend/src/mocks/data/connections.ts
@@ -20,7 +20,8 @@ const connections:Connection[] = [
 			cert_path: "./certs/cert.pem",
 			key_path: "./certs/key.pem",
 			ca_path: "./certs/ca.pem",
-		}
+		},
+		inboxPrefix: "_INBOX"
 	},
 	{
 		id: "cnn-2",
@@ -33,6 +34,7 @@ const connections:Connection[] = [
 		auth: [
 			{ mode: AUTH_MODE.CREDS_FILE, creds: "myfle.cred" }
 		],
+		inboxPrefix: "_INBOX.custom"
 	},
 	{
 		id: "cnn-3",

--- a/frontend/src/stores/stacks/sync/index.ts
+++ b/frontend/src/stores/stacks/sync/index.ts
@@ -16,12 +16,15 @@ const setup = {
 
 	state: {
 		connectionId: <string>null,
-		messageReceived: "",
-		messageSend: "",
 		subject: "",
+		messageSend: "",
+		timeoutMs: 2000,
 		headers: <[string, string][]>[],
+
+		messageReceived: "",
 		headersReceived: {},
 
+		optionsOpen: false,
 
 		loadingState: LOAD_STATE.IDLE,
 
@@ -72,7 +75,7 @@ const setup = {
 					store.state.subject,
 					store.state.messageSend,
 					store.state.headers,
-					null,
+					store.state.timeoutMs,
 					{ store }
 				)
 				store.setMessageReceived(resp.payload)
@@ -103,6 +106,9 @@ const setup = {
 		setMessageSend: (messageSend: string) => ({ messageSend }),
 		setSubject: (subject: string) => ({ subject }),
 		setHeaders: (headers: [string,string][]) => ({ headers }),
+		setTimeoutMs: (timeoutMs) => ({ timeoutMs }),
+		setOptionsOpen: (optionsOpen: boolean) => ({ optionsOpen }),
+
 	},
 }
 

--- a/frontend/src/types/Connection.ts
+++ b/frontend/src/types/Connection.ts
@@ -2,6 +2,7 @@ export interface Connection {
     id?: string
     name: string
     hosts: string[]
+    inboxPrefix: string
     subscriptions: Subscription[]
     auth: Auth[]
     tlsAuth: TLSAuth

--- a/internal/connection/entities.go
+++ b/internal/connection/entities.go
@@ -4,6 +4,7 @@ type Connection struct {
 	Id            string         `json:"id" `
 	Name          string         `json:"name" `
 	Hosts         []string       `json:"hosts" `
+	InboxPrefix   string         `json:"inbox_prefix"`
 	Subscriptions []Subscription `clover:"subscriptions" json:"subscriptions"`
 	Auth          []Auth         `json:"auth" `
 	TLSAuth       TLSAuth        `clover:"tls_auth" json:"tls_auth" `

--- a/internal/connection/pool.go
+++ b/internal/connection/pool.go
@@ -94,6 +94,7 @@ func natsBuilder(connection *Connection) (*NatsConn, error) {
 	}
 	options = appendAuthOption(connection, options)
 	options = appendTLSAuthOptions(connection, options)
+	options = appendInboxPrefixOption(connection, options)
 	return NewNatsConn(strings.Join(connection.Hosts, ", "), options...)
 }
 
@@ -137,6 +138,13 @@ func appendTLSAuthOptions(connection *Connection, options []nats.Option) []nats.
 		if connection.TLSAuth.CaPath != "" {
 			options = append(options, nats.RootCAs(connection.TLSAuth.CaPath))
 		}
+	}
+	return options
+}
+
+func appendInboxPrefixOption(connection *Connection, options []nats.Option) []nats.Option {
+	if connection.InboxPrefix != "" {
+		options = append(options, nats.CustomInboxPrefix(connection.InboxPrefix))
 	}
 	return options
 }

--- a/internal/nui/messages.go
+++ b/internal/nui/messages.go
@@ -11,7 +11,7 @@ type msgReq struct {
 	Subject   string      `json:"subject"`
 	Payload   []byte      `json:"payload"`
 	Headers   nats.Header `json:"headers"`
-	TimeoutMs int         `json:"timeoutMs"`
+	TimeoutMs int         `json:"timeout_ms"`
 }
 
 func (a *App) handleIndexSubscriptions(c *fiber.Ctx) error {
@@ -98,7 +98,11 @@ func (a *App) handleRequest(c *fiber.Ctx) error {
 	reqMsg.Header = req.Headers
 
 	replyMsg, err := conn.RequestMsg(reqMsg, timeout)
+
 	if err != nil {
+		if err == nats.ErrTimeout {
+			return a.logAndFiberError(c, err, 408)
+		}
 		return a.logAndFiberError(c, err, 500)
 	}
 	reply := &struct {

--- a/internal/nui/messages.go
+++ b/internal/nui/messages.go
@@ -4,15 +4,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-nui/nui/internal/connection"
-	"time"
 )
-
-type msgReq struct {
-	Subject   string      `json:"subject"`
-	Payload   []byte      `json:"payload"`
-	Headers   nats.Header `json:"headers"`
-	TimeoutMs int         `json:"timeout_ms"`
-}
 
 func (a *App) handleIndexSubscriptions(c *fiber.Ctx) error {
 	if c.Params("id") == "" {
@@ -71,44 +63,4 @@ func (a *App) handlePublish(c *fiber.Ctx) error {
 		return a.logAndFiberError(c, err, 500)
 	}
 	return c.SendStatus(200)
-}
-
-func (a *App) handleRequest(c *fiber.Ctx) error {
-	if c.Params("id") == "" {
-		return c.Status(422).JSON("id is required")
-	}
-	conn, err := a.nui.ConnPool.Get(c.Params("id"))
-	if err != nil {
-		return a.logAndFiberError(c, err, 404)
-	}
-	req := &msgReq{}
-	err = c.BodyParser(req)
-	if err != nil {
-		return a.logAndFiberError(c, err, 422)
-	}
-	timeout := 2000 * time.Millisecond
-	if req.TimeoutMs > 0 {
-		timeout = time.Duration(req.TimeoutMs) * time.Millisecond
-	}
-	if err != nil {
-		return a.logAndFiberError(c, err, 422)
-	}
-	reqMsg := nats.NewMsg(req.Subject)
-	reqMsg.Data = req.Payload
-	reqMsg.Header = req.Headers
-
-	replyMsg, err := conn.RequestMsg(reqMsg, timeout)
-
-	if err != nil {
-		if err == nats.ErrTimeout {
-			return a.logAndFiberError(c, err, 408)
-		}
-		return a.logAndFiberError(c, err, 500)
-	}
-	reply := &struct {
-		Subject string      `json:"subject"`
-		Payload []byte      `json:"payload"`
-		Headers nats.Header `json:"headers"`
-	}{Payload: replyMsg.Data, Subject: replyMsg.Subject, Headers: replyMsg.Header}
-	return c.JSON(reply)
 }

--- a/internal/nui/req_reply.go
+++ b/internal/nui/req_reply.go
@@ -1,0 +1,54 @@
+package nui
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/nats-io/nats.go"
+	"time"
+)
+
+type msgReq struct {
+	Subject   string      `json:"subject"`
+	Payload   []byte      `json:"payload"`
+	Headers   nats.Header `json:"headers"`
+	TimeoutMs int         `json:"timeout_ms"`
+}
+
+func (a *App) handleRequest(c *fiber.Ctx) error {
+	if c.Params("id") == "" {
+		return c.Status(422).JSON("id is required")
+	}
+	conn, err := a.nui.ConnPool.Get(c.Params("id"))
+	if err != nil {
+		return a.logAndFiberError(c, err, 404)
+	}
+	req := &msgReq{}
+	err = c.BodyParser(req)
+	if err != nil {
+		return a.logAndFiberError(c, err, 422)
+	}
+	timeout := 2000 * time.Millisecond
+	if req.TimeoutMs > 0 {
+		timeout = time.Duration(req.TimeoutMs) * time.Millisecond
+	}
+	if err != nil {
+		return a.logAndFiberError(c, err, 422)
+	}
+	reqMsg := nats.NewMsg(req.Subject)
+	reqMsg.Data = req.Payload
+	reqMsg.Header = req.Headers
+
+	replyMsg, err := conn.RequestMsg(reqMsg, timeout)
+
+	if err != nil {
+		if err == nats.ErrTimeout {
+			return a.logAndFiberError(c, err, 408)
+		}
+		return a.logAndFiberError(c, err, 500)
+	}
+	reply := &struct {
+		Subject string      `json:"subject"`
+		Payload []byte      `json:"payload"`
+		Headers nats.Header `json:"headers"`
+	}{Payload: replyMsg.Data, Subject: replyMsg.Subject, Headers: replyMsg.Header}
+	return c.JSON(reply)
+}


### PR DESCRIPTION
PR related to:
- add support for custom timeout when sending a request
-   allow to specify in the connection a custom inbox for replies

Implementation:
- added an options dialog in request / reply card with default editable timeout
- added an additional section on connection card with new field for custom inbox

`MaxTimeCmp` component is improved to:
- output a time duration in different units instead of nanoseconds only (props defaults to nanoseconds)
- auto select the best unit to show when component is loaded defaulting to the largest unit that can be see as an integer (eg if the field is in milliseconds and value is 20000, it shows 20 seconds)

