### PR TITLE
Fixed a typo in workqueue

### DIFF
--- a/frontend/docs/entities/stream/def/stream-config.md
+++ b/frontend/docs/entities/stream/def/stream-config.md
@@ -130,7 +130,7 @@ STORAGE {
 RETENTION {
 	LIMIT = "limits",
 	INTEREST = "interest",
-	WORKQUEQUE = "workqueque",
+	WORKQUEUE = "workqueue",
 }
 ```
 

--- a/frontend/src/types/Stream.ts
+++ b/frontend/src/types/Stream.ts
@@ -119,7 +119,7 @@ export enum STORAGE {
 export enum RETENTION {
 	LIMIT = "limits",
 	INTEREST = "interest",
-	WORKQUEQUE = "workqueque",
+	WORKQUEUE = "workqueue",
 }
 
 export enum DISCARD {


### PR DESCRIPTION
Fixed a typo in `workqueue` that prevented the creation of a stream with such retention policy.
![изображение](https://github.com/user-attachments/assets/858d0b9d-a86d-4821-8c0b-9d343aa9b8c8)
