### PR TITLE
[NUI-203] - 36 - Run docker container as NUI non-root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+credentials
+db
+.idea
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 ## be build
 FROM golang:1.21 AS build_be
 ARG VERSION
@@ -16,9 +15,20 @@ RUN npm run build
 ### production image
 FROM alpine:3
 WORKDIR /
+# Install deps
 RUN apk add libc6-compat
+
+# Create regular NUI user account
+RUN addgroup -g 1001 nui && \
+    adduser -u 1001 -D nui -G nui -s /bin/sh
+
+# Copy the needed binary from the builder stage
 COPY --from=build_be /cmd/nui-web /cmd/nui-web
 COPY --from=build_fe /frontend/dist /frontend/dist
+RUN chown -R nui:nui /cmd/nui-web /frontend
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 31311/tcp
-ENTRYPOINT ["/cmd/nui-web"]
-CMD ["--db-path=/db"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "8222:8222"
   nui:
     image: ghcr.io/nats-nui/nui:edge
+    volumes:
+      - ./db:/db
     ports:
       - "31312:31311"
     depends_on:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,5 +9,12 @@ fi
 
 ARGS="--db-path=/db ${@}"
 
-# Switch to nui user and execute with all arguments
-exec su -c "/cmd/nui-web ${ARGS}" nui
+# Check if the current user UID is 1001 to support running as a different as non-root user
+# also the entrypoint
+if [ "$(id -u)" -eq 1001 ]; then
+  # Start the process directly
+  exec /cmd/nui-web ${ARGS}
+else
+  # Switch to nui user and execute with all arguments
+  exec su -c "/cmd/nui-web ${ARGS}" nui
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+
+# Backwards compatibility for docker version that run NUI as root user
+# Change ownership of /db if it exists
+if [ -d "/db" ]; then
+  chown -R nui:nui /db
+fi
+
+ARGS="--db-path=/db ${@}"
+
+# Switch to nui user and execute with all arguments
+exec su -c "/cmd/nui-web ${ARGS}" nui


### PR DESCRIPTION
solves #36 introducing a non root NUI user to run the container application, keeping compatibility with already-running instances that uses root as user.
To do so:
- the container entrypoint is executed as root to chown existing db to `nui` user.
- the application is started as `nui` user.