### PR TITLE
fix(frontend): fix encoding problem in browser for streams

### DIFF
--- a/frontend/src/plugins/AjaxService.ts
+++ b/frontend/src/plugins/AjaxService.ts
@@ -176,7 +176,7 @@ export class AjaxService {
             .map((segment, index) => {
                 // Don't encode the empty segments that appear when the path starts or ends with /
                 // or when there are consecutive slashes
-                return segment === '' ? segment : encodeURIComponent(segment);
+                return segment === '' ? segment : encodeURI(segment);
             })
             .join('/').concat(queryString);
 


### PR DESCRIPTION
This problem related to #64 
For the solution use this^ `encodeURI()`
Because of this "function encodes more characters, including those that are part of the URI syntax"

More read here: [Mozilla docs encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)

I tested and it work fine in web version.