### PR TITLE
fix(nui): delete JetStream consumer even when it’s push-based

### DIFF
--- a/internal/nui/consumers.go
+++ b/internal/nui/consumers.go
@@ -2,9 +2,10 @@ package nui
 
 import (
 	"errors"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/nats-io/nats.go/jetstream"
-	"time"
 )
 
 func (a *App) HandleIndexStreamConsumers(c *fiber.Ctx) error {
@@ -139,6 +140,9 @@ func (a *App) handleDeleteStreamConsumer(c *fiber.Ctx) error {
 		return a.logAndFiberError(c, err, 422)
 	}
 	_, err = stream.Consumer(c.Context(), c.Params("consumer_name"))
+	if errors.Is(err, jetstream.ErrNotPullConsumer) {
+		_, err = stream.PushConsumer(c.Context(), c.Params("consumer_name"))
+	}
 	if err != nil {
 		return a.logAndFiberError(c, err, 422)
 	}


### PR DESCRIPTION
### Summary
Deleting consumers failed for push-based consumers because we fetched them via
`stream.Consumer(...)` (pull-only). This change falls back to
`stream.PushConsumer(...)` when `ErrNotPullConsumer` is returned, then proceeds
to delete the consumer.

### Motivation
Users can create JetStream consumers as either pull or push. Deletion should
work regardless of the delivery type.

### Technical Notes
- Try `stream.Consumer(ctx, name)`; on `ErrNotPullConsumer`, call
  `stream.PushConsumer(ctx, name)`.
- Keep existing HTTP responses (422 for client issues, 500 for server failures,
  204 on success).
- No API surface change.

### Testing
- Create a **pull** consumer, then call DELETE: expect 204.
- Create a **push** consumer (with `DeliverSubject`), then call DELETE: expect 204.
- Try deleting a non-existent consumer: expect 422 with error payload.
- Fault-inject JS error: expect 500.

### Risks
Low; only affects delete path and narrows error cases.

### Checklist
- [x] Code compiles
- [x] Linted
- [x] Manual tests against local NATS/JetStream