### PR TITLE
feat: configure Monaco Editor to use local package instead of CDN

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,13 @@ import '@/plugins/msw';
 
 import ReactDOM from 'react-dom/client';
 import App from './app/App.tsx';
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 
 import '@fontsource/darker-grotesque/800.css';
 import '@fontsource-variable/inter';
@@ -17,6 +24,25 @@ import './css/monaco.css';
 import "@priolo/jack/dist/jack.css";
 import './css/label.css';
 
+(globalThis as any).MonacoEnvironment = {
+	getWorker: (_: string, label: string) => {
+		if (label === 'json') {
+			return new jsonWorker();
+		}
+		if (label === 'css' || label === 'scss' || label === 'less') {
+			return new cssWorker();
+		}
+		if (label === 'html' || label === 'handlebars' || label === 'razor') {
+			return new htmlWorker();
+		}
+		if (label === 'typescript' || label === 'javascript') {
+			return new tsWorker();
+		}
+		return new editorWorker();
+	},
+};
+
+loader.config({ monaco });
 
 import "./utils/session/startup.ts";
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig (( ) => {
                 'react': path.resolve(__dirname, './node_modules/react'),
                 'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
             }
+        },
+        worker: {
+            format: 'es'
         }
     }
 })


### PR DESCRIPTION
Configure Monaco Editor to load from the local monaco-editor package instead of fetching from CDN. This enables offline functionality and improves reliability.

Changes:
- Import Monaco workers directly from local package using Vite's worker system (?worker suffix)
- Configure MonacoEnvironment to provide workers for different language types (JSON, CSS, HTML, TypeScript/JavaScript)
- Configure Monaco loader to use local monaco instance
- Add worker configuration to vite.config.ts for ES module format

Fixes worker loading errors that occurred when Monaco tried to resolve worker URLs from CDN.