### PR TITLE
feat: subscription auto-cleanup and socket disconnect fix

### DIFF
--- a/frontend/src/components/formatters/divider/DividerRow.tsx
+++ b/frontend/src/components/formatters/divider/DividerRow.tsx
@@ -1,3 +1,5 @@
+import CloseIcon from "@/icons/CloseIcon"
+import { IconButton, TooltipWrapCmp } from "@priolo/jack"
 import { FunctionComponent } from "react"
 import cls from "./DividerRow.module.css"
 
@@ -15,6 +17,7 @@ interface Props {
 	children?: React.ReactNode
 	time?: string
 	onClick?: () => void
+	onDelete?: () => void
 	variant?: DIVIDER_VARIANT
 
 	style?: React.CSSProperties,
@@ -26,6 +29,7 @@ const DividerRow: FunctionComponent<Props> = ({
 	children,
 	time,
 	onClick,
+	onDelete,
 	variant = DIVIDER_VARIANT.BORDER_UP,
 
 	style,
@@ -37,10 +41,15 @@ const DividerRow: FunctionComponent<Props> = ({
 	// HOOKs
 
 	// HANDLER
+	const handleDeleteClick = (e: React.MouseEvent) => {
+		e.preventDefault()
+		e.stopPropagation()
+		onDelete?.()
+	}
 
 	// RENDER
 	const clsSelected = !!onClick ? cls.selected : ""
-	const clsRoot = `${cls.root} ${clsSelected} ${className}`
+	const clsRoot = `${cls.root} ${clsSelected} ${className} jack-hover-container`
 
 	return <div
 		className={clsRoot}
@@ -50,7 +59,16 @@ const DividerRow: FunctionComponent<Props> = ({
 		{(variant == DIVIDER_VARIANT.BORDER_UP || variant == DIVIDER_VARIANT.BORDER_BOTH) && (
 			<div className="jack-bars-alert-bg" style={{ height: 10 }} />
 		)}
-		<div className={cls.title}>{title}</div>
+		<div className={cls.title} style={{ display: 'flex', alignItems: 'center' }}>
+			<span style={{ flex: 1 }}>{title}</span>
+			{onDelete && (
+				<TooltipWrapCmp content="REMOVE">
+					<IconButton className="jack-hover-hide" onClick={handleDeleteClick}>
+						<CloseIcon style={{ width: 12, height: 12 }} />
+					</IconButton>
+				</TooltipWrapCmp>
+			)}
+		</div>
 		<div className={cls.body}>{children}</div>
 		<div className={cls.footer}>{time}</div>
 		{(variant == DIVIDER_VARIANT.BORDER_DOWN || variant == DIVIDER_VARIANT.BORDER_BOTH) && (

--- a/frontend/src/components/rows/EditSubscriptionRow.tsx
+++ b/frontend/src/components/rows/EditSubscriptionRow.tsx
@@ -51,10 +51,9 @@ const EditSubscriptionRow: FunctionComponent<Props> = ({
 
 	return <Box className={cls.root}
 		readOnly={readOnly}
-		enterRender={<IconButton onClick={handleDelete}><CloseIcon /></IconButton>}
 	>
 		{!noDisable && (
-			<IconToggle 
+			<IconToggle
 				//style={{ marginTop: '5px' }}
 				check={!item.disabled}
 				onChange={handleChangeEnabled}
@@ -62,7 +61,7 @@ const EditSubscriptionRow: FunctionComponent<Props> = ({
 			/>
 		)}
 		{!noFavorite && (
-			<IconToggle 
+			<IconToggle
 				//style={{ marginTop: '5px' }}
 				check={item.favorite}
 				onChange={handleChangeFavorite}
@@ -81,6 +80,14 @@ const EditSubscriptionRow: FunctionComponent<Props> = ({
 			onKeyDown={handleKeyDown}
 			onFocus={onSelect}
 		/>
+		{!readOnly && (
+			<IconButton
+				style={{ marginLeft: 4, opacity: 0.7 }}
+				onClick={handleDelete}
+			>
+				<CloseIcon style={{ width: 14, height: 14 }} />
+			</IconButton>
+		)}
 	</Box>
 }
 

--- a/frontend/src/components/stacks/connections/messages/SubjectsDialog.tsx
+++ b/frontend/src/components/stacks/connections/messages/SubjectsDialog.tsx
@@ -1,12 +1,16 @@
 import EditSubscriptionRow from "@/components/rows/EditSubscriptionRow"
-import { MessageStat, MessagesState, MessagesStore } from "@/stores/stacks/connection/messages"
+import { MessageStat, MessagesState, MessagesStore, SubscriptionHistoryEntry } from "@/stores/stacks/connection/messages"
 import { Subscription } from "@/types"
 import { useStore } from "@priolo/jon"
 import dayjs from "dayjs"
 import { FunctionComponent, useEffect, useMemo, useState } from "react"
 import cls from "./SubjectsDialog.module.css"
-import { Button, Dialog, EditList, FindInput, IconToggle, List, TitleAccordion } from "@priolo/jack"
+import { Button, Dialog, EditList, FindInput, IconToggle, List, NumberInput, TitleAccordion } from "@priolo/jack"
 import { RenderRowBaseProps } from "@priolo/jack"
+
+// Default values for subscription cleanup
+const DEFAULT_TTL_MINUTES = 15
+const DEFAULT_MAX_MESSAGES = 1000
 
 
 
@@ -25,6 +29,11 @@ const SubjectsDialog: FunctionComponent<Props> = ({
 	const [subscriptions, setSubscriptions] = useState<Subscription[]>([])
 	const [filter, setFilter] = useState<string>("")
 
+	// Advanced options state
+	const [ttlMinutes, setTtlMinutes] = useState<number>(DEFAULT_TTL_MINUTES)
+	const [maxMessages, setMaxMessages] = useState<number>(DEFAULT_MAX_MESSAGES)
+	const [sessionBased, setSessionBased] = useState<boolean>(true)
+
 	useEffect(() => {
 		if (!msgSa.subscriptionsOpen) return
 		const subs = msgSa.subscriptions ?? []
@@ -38,7 +47,14 @@ const SubjectsDialog: FunctionComponent<Props> = ({
 	}
 	const handleOk = () => {
 		msgSo.setSubscriptionsOpen(false)
-		msgSo.setSubscriptions(subscriptions)
+		// Apply advanced options to all subscriptions
+		const subsWithOptions = subscriptions.map(sub => ({
+			...sub,
+			ttlMinutes,
+			maxMessages,
+			sessionBased,
+		}))
+		msgSo.setSubscriptions(subsWithOptions)
 		msgSo.sendSubscriptions()
 		msgSo.updateSubscriptions()
 	}
@@ -64,6 +80,27 @@ const SubjectsDialog: FunctionComponent<Props> = ({
 	const handleClearStats = () => {
 		msgSo.setStats({})
 	}
+	const handleHistorySelect = (index: number) => {
+		const entry = history[index]
+		if (subscriptions.findIndex(s => s.subject == entry.subject) != -1) {
+			// Already exists, just re-enable it
+			const updated = subscriptions.map(s =>
+				s.subject === entry.subject ? { ...s, disabled: false } : s
+			)
+			setSubscriptions(updated)
+		} else {
+			// Add as new subscription
+			subscriptions.push({
+				subject: entry.subject,
+				disabled: false,
+				favorite: false,
+			})
+			setSubscriptions([...subscriptions])
+		}
+	}
+	const handleClearHistory = () => {
+		msgSo.clearSubscriptionHistory()
+	}
 
 	// RENDER
 	const allCheck = useMemo(() => subscriptions.every(s => !s.disabled), [subscriptions])
@@ -74,6 +111,8 @@ const SubjectsDialog: FunctionComponent<Props> = ({
 			.sort((s1, s2) => s1.subject.localeCompare(s2.subject))
 	}, [filter, msgSa.stats, msgSa.messages])
 	const noStats = !stats || stats.length == 0
+	const history = msgSa.subscriptionHistory || []
+	const noHistory = history.length === 0
 
 	return <Dialog noCloseOnClickParent
 		title={<div style={{ display: "flex", alignItems: "center" }}>
@@ -98,6 +137,38 @@ const SubjectsDialog: FunctionComponent<Props> = ({
 				RenderRow={EditSubscriptionRow}
 			/>
 
+			<TitleAccordion title="ADVANCED" open={false}>
+				<div className="jack-lyt-form" style={{ padding: "5px 0" }}>
+					<div className="jack-cmp-h">
+						<div className="jack-lbl-prop" style={{ minWidth: 120 }}>TTL (minutes)</div>
+						<NumberInput
+							style={{ flex: 1 }}
+							value={ttlMinutes}
+							onChange={v => setTtlMinutes(v ?? DEFAULT_TTL_MINUTES)}
+							min={1}
+							max={480}
+						/>
+					</div>
+					<div className="jack-cmp-h">
+						<div className="jack-lbl-prop" style={{ minWidth: 120 }}>Max Messages</div>
+						<NumberInput
+							style={{ flex: 1 }}
+							value={maxMessages}
+							onChange={v => setMaxMessages(v ?? DEFAULT_MAX_MESSAGES)}
+							min={1}
+							max={100000}
+						/>
+					</div>
+					<div className="jack-cmp-h">
+						<IconToggle
+							check={sessionBased}
+							onChange={() => setSessionBased(!sessionBased)}
+						/>
+						<div className="jack-lbl-prop">Remove on disconnect</div>
+					</div>
+				</div>
+			</TitleAccordion>
+
 			<TitleAccordion title="STATS" open={false}>
 				{!noStats &&
 					<FindInput
@@ -113,6 +184,22 @@ const SubjectsDialog: FunctionComponent<Props> = ({
 					RenderRow={MessageStatRow}
 				/>
 			</TitleAccordion>
+
+			{!noHistory && (
+				<TitleAccordion title="HISTORY (EXPIRED)" open={false}>
+					<List<SubscriptionHistoryEntry>
+						className={cls.list}
+						items={history}
+						onSelect={handleHistorySelect}
+						RenderRow={HistoryEntryRow}
+					/>
+					<Button
+						style={{ marginTop: 5, fontSize: 10 }}
+						children="CLEAR HISTORY"
+						onClick={handleClearHistory}
+					/>
+				</TitleAccordion>
+			)}
 
 			<div className="jack-cmp-h" style={{ marginTop: 10 }}>
 				<IconToggle
@@ -145,6 +232,27 @@ const MessageStatRow: FunctionComponent<RenderRowBaseProps<MessageStat>> = ({
 		<div className={cls.row_sbj}>{item.subject}</div>
 		<div style={{ display: "flex" }}>
 			<div className={cls.row_counter}>{item.counter}</div>
+			<div style={{ flex: 1 }} />
+			<div className={cls.row_time}>{time}</div>
+		</div>
+	</div>
+}
+
+const HistoryEntryRow: FunctionComponent<RenderRowBaseProps<SubscriptionHistoryEntry>> = ({
+	item,
+}) => {
+	const time = useMemo(() => dayjs(item.expiredAt).format("YYYY-MM-DD HH:mm:ss"), [item.expiredAt])
+	const reasonText = {
+		ttl: "TTL",
+		max_messages: "Max msgs",
+		disconnect: "Disconnect",
+		limit: "Limit"
+	}[item.reason] || item.reason
+
+	return <div className={cls.row}>
+		<div className={cls.row_sbj}>{item.subject}</div>
+		<div style={{ display: "flex" }}>
+			<div className={cls.row_counter} style={{ color: "var(--color-yellow)" }}>{reasonText}</div>
 			<div style={{ flex: 1 }} />
 			<div className={cls.row_time}>{time}</div>
 		</div>

--- a/frontend/src/components/stacks/connections/messages/View.tsx
+++ b/frontend/src/components/stacks/connections/messages/View.tsx
@@ -55,6 +55,10 @@ const MessagesView: FunctionComponent<Props> = ({
 		}
 	}
 	const hendleMessageClick = (message: Message) => msgSo.openMessageDetail(message)
+	const handleMessageDelete = (message: Message) => {
+		const filtered = msgSa.messages.filter(m => m !== message)
+		msgSo.setMessages(filtered)
+	}
 	const handleClear = () => msgSo.setMessages([])
 	const handleSearchChange = (value: string) => {
 		setTextFind(value)
@@ -111,6 +115,7 @@ const MessagesView: FunctionComponent<Props> = ({
 			selectedIndex={selectedIndex}
 			format={msgSa.format}
 			onMessageClick={hendleMessageClick}
+			onMessageDelete={handleMessageDelete}
 			onClear={handleClear}
 			style={{ marginLeft: '-10px', marginRight: '-10px' }}
 			extraActions={<FloatButton onClick={handlePause}>

--- a/frontend/src/components/stacks/messages/MessageRow.tsx
+++ b/frontend/src/components/stacks/messages/MessageRow.tsx
@@ -60,6 +60,7 @@ const MessageRow: FunctionComponent<Props> = ({
 		title={message.subject}
 		children={message.payload}
 		time={time}
+		onDelete={onDelete ? () => onDelete(message) : undefined}
 	/>
 
 	return (

--- a/frontend/src/plugins/SocketService/types.ts
+++ b/frontend/src/plugins/SocketService/types.ts
@@ -11,6 +11,8 @@ export interface SocketOptions {
 export enum MSG_TYPE {
     /** SUBSCRIPTIONS REQUEST - client */
     SUB_REQUEST = "subscriptions_req",
+    /** DISCONNECT REQUEST - client */
+    DISCONNECT_REQ = "disconnect_req",
     /** NATS MESSAGE - server */
     NATS_MESSAGE = "nats_msg",
     /** CONNECTION STATUS - server */
@@ -19,6 +21,8 @@ export enum MSG_TYPE {
     METRICS_REQ = "metrics_req",
     /** METRICS - server*/
     METRICS_RESP = "metrics_resp",
+    /** SUBSCRIPTION EXPIRED - server */
+    SUB_EXPIRED = "subscription_expired",
     /** ERROR MESSAGE - client server */
     ERROR = "error",
 }
@@ -31,6 +35,14 @@ export interface SocketMessage {
 /** SUBSCRIPTIONS REQUEST - client */
 export type PayloadSub = {
     subjects: string[]
+    ttl_minutes?: number
+    max_messages?: number
+    session_based?: boolean
+}
+/** SUBSCRIPTION EXPIRED - server */
+export type PayloadSubExpired = {
+    subject: string
+    reason: "ttl" | "max_messages" | "disconnect" | "limit"
 }
 /** NATS MESSAGE - server */
 export type PayloadMessage = {
@@ -51,4 +63,4 @@ export type PayloadError = {
 export type PayloadMetrics = any
 
 
-export type Payload = PayloadSub | PayloadMessage | PayloadStatus | PayloadError | PayloadMetrics
+export type Payload = PayloadSub | PayloadSubExpired | PayloadMessage | PayloadStatus | PayloadError | PayloadMetrics

--- a/frontend/src/types/Connection.ts
+++ b/frontend/src/types/Connection.ts
@@ -33,6 +33,10 @@ export interface Subscription {
     subject: string
     disabled?: boolean
     favorite?: boolean
+    // Advanced options for auto-cleanup
+    ttlMinutes?: number      // Time-to-live in minutes (default: 15)
+    maxMessages?: number     // Max messages before auto-unsubscribe (default: 1000)
+    sessionBased?: boolean   // Remove when WebSocket disconnects (default: true)
 }
 
 export interface CliImport {

--- a/internal/connection/entities.go
+++ b/internal/connection/entities.go
@@ -27,7 +27,12 @@ func (c *Connection) SetMetadata(key, value string) {
 }
 
 type Subscription struct {
-	Subject string `json:"subject"`
+	Subject      string `json:"subject"`
+	Disabled     bool   `json:"disabled,omitempty"`
+	Favorite     bool   `json:"favorite,omitempty"`
+	TTLMinutes   int    `json:"ttl_minutes,omitempty"`
+	MaxMessages  int    `json:"max_messages,omitempty"`
+	SessionBased bool   `json:"session_based,omitempty"`
 }
 
 type Auth struct {

--- a/internal/nui/nui.go
+++ b/internal/nui/nui.go
@@ -43,7 +43,8 @@ func Setup(dbPath, protoschemasPath string, logger logging.Slogger) (*Nui, error
 	}
 	n.CliConnImporter = clicontext.NewImporter(logger)
 	n.MetricsCollector = metrics.NewCollector(n.ConnRepo, connection.NatsBuilder)
-	n.Hub = ws.NewNatsHub(n.ConnPool, n.MetricsCollector, logger)
+	hub := ws.NewNatsHub(n.ConnPool, n.MetricsCollector, logger)
+	n.Hub = hub
 	n.l = logger
 	return n, nil
 }

--- a/internal/ws/clientconn.go
+++ b/internal/ws/clientconn.go
@@ -3,15 +3,29 @@ package ws
 import (
 	"context"
 	"sync"
+	"time"
 )
 
+// MaxSubscriptionsPerUser is the limit of active subscriptions per user
+const MaxSubscriptionsPerUser = 10
+
+// DisconnectGracePeriod is the time to wait before cleaning up subscriptions on disconnect
+const DisconnectGracePeriod = 30 * time.Second
+
 type ClientConn[S Subscription] struct {
-	ConnectionId  string
-	Req           <-chan *Request
-	Messages      chan<- Payload
-	Subs          []ClientSub[S]
-	l             sync.Mutex
-	MetricsCancel context.CancelFunc
+	ConnectionId     string
+	Req              <-chan *Request
+	Messages         chan<- Payload
+	Subs             []ClientSub[S]
+	l                sync.Mutex
+	MetricsCancel    context.CancelFunc
+	ParserCancel     context.CancelFunc
+	TTLCheckerCancel context.CancelFunc
+	TTLMinutes       int  // Default TTL for subscriptions
+	MaxMessages      int  // Default max messages for subscriptions
+	SessionBased     bool // Whether to remove subscriptions on disconnect
+	DisconnectTimer  *time.Timer
+	UserID           string // For tracking per-user limits
 }
 
 func (c *ClientConn[S]) UnsubscribeAll() {
@@ -36,5 +50,73 @@ func NewWClientConn[S Subscription](connectionId string, req <-chan *Request, me
 		Req:          req,
 		Messages:     messages,
 		Subs:         []ClientSub[S]{},
+		TTLMinutes:   15,   // Default 15 minutes
+		MaxMessages:  1000, // Default 1000 messages
+		SessionBased: true, // Default remove on disconnect
 	}
+}
+
+// SubscriptionCount returns the current number of active subscriptions
+func (c *ClientConn[S]) SubscriptionCount() int {
+	c.l.Lock()
+	defer c.l.Unlock()
+	return len(c.Subs)
+}
+
+// CanAddSubscription checks if more subscriptions can be added (within limit)
+func (c *ClientConn[S]) CanAddSubscription(count int) bool {
+	c.l.Lock()
+	defer c.l.Unlock()
+	return len(c.Subs)+count <= MaxSubscriptionsPerUser
+}
+
+// RemoveExpiredSubscriptions removes subscriptions that have expired and returns them
+func (c *ClientConn[S]) RemoveExpiredSubscriptions() []ClientSub[S] {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	var expired []ClientSub[S]
+	var active []ClientSub[S]
+
+	for _, sub := range c.Subs {
+		if sub.IsExpired() {
+			_ = sub.Sub.Unsubscribe()
+			close(sub.Messages)
+			expired = append(expired, sub)
+		} else {
+			active = append(active, sub)
+		}
+	}
+
+	c.Subs = active
+	return expired
+}
+
+// RemoveSubscription removes a subscription by subject and closes its channel
+func (c *ClientConn[S]) RemoveSubscription(subject string) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	var active []ClientSub[S]
+	for _, sub := range c.Subs {
+		if sub.Subject == subject {
+			close(sub.Messages)
+		} else {
+			active = append(active, sub)
+		}
+	}
+	c.Subs = active
+}
+
+// SetSubscriptionOptions sets the default options for new subscriptions
+func (c *ClientConn[S]) SetSubscriptionOptions(ttlMinutes, maxMessages int, sessionBased bool) {
+	c.l.Lock()
+	defer c.l.Unlock()
+	if ttlMinutes > 0 {
+		c.TTLMinutes = ttlMinutes
+	}
+	if maxMessages > 0 {
+		c.MaxMessages = maxMessages
+	}
+	c.SessionBased = sessionBased
 }

--- a/internal/ws/clientsub.go
+++ b/internal/ws/clientsub.go
@@ -1,16 +1,55 @@
 package ws
 
-import "github.com/nats-io/nats.go"
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
 
 type ClientSub[S Subscription] struct {
-	Subject  string
-	Messages chan *nats.Msg
-	Sub      S
+	Subject      string
+	Messages     chan *nats.Msg
+	Sub          S
+	CreatedAt    time.Time
+	TTLMinutes   int
+	MaxMessages  int
+	MessageCount atomic.Int64
+	Expired      atomic.Bool
 }
 
-func NewClientSub[S Subscription](subject string) ClientSub[S] {
+func NewClientSub[S Subscription](subject string, ttlMinutes, maxMessages int) ClientSub[S] {
 	return ClientSub[S]{
-		Subject:  subject,
-		Messages: make(chan *nats.Msg, 10),
+		Subject:     subject,
+		Messages:    make(chan *nats.Msg, 10),
+		CreatedAt:   time.Now(),
+		TTLMinutes:  ttlMinutes,
+		MaxMessages: maxMessages,
 	}
+}
+
+// IncrementMessageCount increments the message counter and returns true if max messages exceeded
+func (c *ClientSub[S]) IncrementMessageCount() bool {
+	count := c.MessageCount.Add(1)
+	if c.MaxMessages > 0 && int(count) >= c.MaxMessages {
+		return true
+	}
+	return false
+}
+
+// IsExpired checks if the subscription has expired due to TTL
+func (c *ClientSub[S]) IsExpired() bool {
+	if c.Expired.Load() {
+		return true
+	}
+	if c.TTLMinutes > 0 {
+		expiryTime := c.CreatedAt.Add(time.Duration(c.TTLMinutes) * time.Minute)
+		return time.Now().After(expiryTime)
+	}
+	return false
+}
+
+// MarkExpired marks the subscription as expired
+func (c *ClientSub[S]) MarkExpired() {
+	c.Expired.Store(true)
 }

--- a/internal/ws/entities.go
+++ b/internal/ws/entities.go
@@ -3,8 +3,9 @@ package ws
 import "time"
 
 const (
-	subReqType  = "subscriptions_req"
-	natsMsgType = "nats_msg"
+	subReqType     = "subscriptions_req"
+	natsMsgType    = "nats_msg"
+	disconnectType = "disconnect_req"
 
 	connectionStatusType = "connection_status"
 
@@ -69,11 +70,35 @@ func (s Error) GetType() string {
 }
 
 type SubsReq struct {
-	Subjects []string `json:"subjects" mapstructure:"subjects"`
+	Subjects     []string `json:"subjects" mapstructure:"subjects"`
+	TTLMinutes   int      `json:"ttl_minutes" mapstructure:"ttl_minutes"`     // Time-to-live in minutes (default: 15)
+	MaxMessages  int      `json:"max_messages" mapstructure:"max_messages"`   // Max messages before auto-unsubscribe (default: 1000)
+	SessionBased bool     `json:"session_based" mapstructure:"session_based"` // Remove on WebSocket disconnect (default: true)
 }
 
 func (s SubsReq) GetType() string {
 	return subReqType
+}
+
+// DisconnectReq is sent by client when explicitly closing the window
+type DisconnectReq struct{}
+
+func (d DisconnectReq) GetType() string {
+	return disconnectType
+}
+
+// Subscription expiry notification types
+const (
+	subExpiredType = "subscription_expired"
+)
+
+type SubExpired struct {
+	Subject string `json:"subject"`
+	Reason  string `json:"reason"` // "ttl", "max_messages", "disconnect", "limit"
+}
+
+func (s SubExpired) GetType() string {
+	return subExpiredType
 }
 
 type MetricsReq struct {

--- a/pkg/channels/fanin.go
+++ b/pkg/channels/fanin.go
@@ -1,13 +1,25 @@
 package channels
 
+import "sync"
+
 func FanIn[T any](buffer int, ins ...<-chan T) <-chan T {
 	out := make(chan T, buffer)
+	var wg sync.WaitGroup
+	wg.Add(len(ins))
+
 	for _, c := range ins {
 		go func(c <-chan T) {
+			defer wg.Done()
 			for n := range c {
 				out <- n
 			}
 		}(c)
 	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
 	return out
 }


### PR DESCRIPTION
## Summary
- Add subscription auto-cleanup with TTL, max messages, and history settings
- Show expiry time in subscription messages
- Add X button to remove individual messages from list
- Fix socket disconnect when window is moving

## Changes
- Frontend: Added subscription settings dialog with TTL/max messages/history options
- Frontend: Added expiry time display and remove button for messages
- Backend: Implemented subscription cleanup logic with configurable TTL
- Backend: Fixed WebSocket connection stability during window movement

> Re-opened from #112 after removing accidentally committed secrets from git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)