### PR TITLE
fix: display protobuf enums as numbers instead of strings

### DIFF
--- a/frontend/src/utils/protobuf.ts
+++ b/frontend/src/utils/protobuf.ts
@@ -189,7 +189,7 @@ export function decodeProtobufMessage(
 
     const object = messageType.toObject(decoded, {
       longs: String,
-      enums: String,
+      enums: Number,
       bytes: String,
       arrays: true,
       objects: true,


### PR DESCRIPTION
 ## Summary
  Fixed protobuf enum display to show numeric values instead of verbose constant names.

  ## Problem
  When decoding protobuf messages, enum fields were displaying full constant names instead of numeric values:

  **Before:**
  ```
  "severity_number": "SEVERITY_NUMBER_INFO"
  ```
  **After**:
  ```
  "severity_number": 1
  ```
  Changes

  - Changed enums: String to enums: Number in frontend/src/utils/protobuf.ts

  Why

  Displaying values of enummake your protobuf display more accurate to it's underlaying data
  If someone want to display text, then field should be string, not enum