### PR TITLE
fix(protobuf): preserve dots in cached message types and survive external cache clears

### DIFF
--- a/frontend/src/utils/protobuf/ProtobufTopicCache.ts
+++ b/frontend/src/utils/protobuf/ProtobufTopicCache.ts
@@ -29,19 +29,31 @@ interface SerializedNode {
 
 export class ProtobufTopicCache {
   private trie = new TopicTrie()
+  private dirty = false
   private saveOnUnload = () => this.save()
+  private onStorageChange = (event: StorageEvent) => {
+    // Re-sync if another tab cleared or modified our key, so the unload
+    // handler does not silently overwrite that change.
+    if (event.storageArea !== localStorage) return
+    if (event.key !== null && event.key !== STORAGE_KEY) return
+    this.trie = new TopicTrie()
+    this.dirty = false
+    this.load()
+  }
   
   constructor() {
     this.load()
     
     if (typeof window !== 'undefined') {
       window.addEventListener('beforeunload', this.saveOnUnload)
+      window.addEventListener('storage', this.onStorageChange)
     }
   }
   
   dispose(): void {
     if (typeof window !== 'undefined') {
       window.removeEventListener('beforeunload', this.saveOnUnload)
+      window.removeEventListener('storage', this.onStorageChange)
     }
   }
   
@@ -66,6 +78,7 @@ export class ProtobufTopicCache {
     try {
       this.trie.insert(sanitizedTopic, sanitizedSchema, sanitizedMessageType)
       this.learnPatterns(sanitizedTopic, sanitizedSchema, sanitizedMessageType)
+      this.dirty = true
       this.save()
     } catch (error) {
       console.warn('Failed to cache successful decode:', error)
@@ -80,6 +93,7 @@ export class ProtobufTopicCache {
     }
     
     this.trie.updateConfidence(topic, false)
+    this.dirty = true
     this.save()
   }
   
@@ -100,6 +114,7 @@ export class ProtobufTopicCache {
     this.trie.updateConfidence(sanitizedTopic, false)
     this.trie.insert(sanitizedTopic, sanitizedSchema, sanitizedMessageType)
     
+    this.dirty = true
     this.save()
   }
   
@@ -160,6 +175,7 @@ export class ProtobufTopicCache {
   
   clear(): void {
     this.trie = new TopicTrie()
+    this.dirty = false
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem(STORAGE_KEY)
     }
@@ -167,10 +183,12 @@ export class ProtobufTopicCache {
   
   private save(): void {
     if (typeof localStorage === 'undefined') return
+    if (!this.dirty) return
     
     try {
       const data = this.serialize(this.trie.getRoot())
       localStorage.setItem(STORAGE_KEY, data)
+      this.dirty = false
     } catch (error) {
       if (error instanceof Error && error.name === 'QuotaExceededError') {
         this.handleStorageOverflow()

--- a/frontend/src/utils/protobuf/validation.test.ts
+++ b/frontend/src/utils/protobuf/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { ProtobufValidator } from './validation'
+
+describe('ProtobufValidator.sanitizeIdentifier', () => {
+  it('preserves dots in fully-qualified protobuf type names', () => {
+    expect(ProtobufValidator.sanitizeIdentifier('my.package.MyMessage'))
+      .toBe('my.package.MyMessage')
+  })
+
+  it('preserves forward slashes in nested schema paths', () => {
+    expect(ProtobufValidator.sanitizeIdentifier('opentelemetry/proto/common/v1/common'))
+      .toBe('opentelemetry/proto/common/v1/common')
+  })
+
+  it('preserves underscores and hyphens', () => {
+    expect(ProtobufValidator.sanitizeIdentifier('my-schema_v1'))
+      .toBe('my-schema_v1')
+  })
+
+  it('strips characters that are not word/dot/dash/slash', () => {
+    expect(ProtobufValidator.sanitizeIdentifier('foo!@#$%^&*()bar'))
+      .toBe('foobar')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(ProtobufValidator.sanitizeIdentifier('   foo.bar  '))
+      .toBe('foo.bar')
+  })
+})
+
+describe('ProtobufValidator.validateAndSanitizeAll', () => {
+  it('round-trips a dotted protobuf message type without mangling', () => {
+    const result = ProtobufValidator.validateAndSanitizeAll(
+      'orders.created',
+      'order_created',
+      'my.package.OrderCreated',
+    )
+    expect(result.isValid).toBe(true)
+    expect(result.sanitized?.messageType).toBe('my.package.OrderCreated')
+  })
+})

--- a/frontend/src/utils/protobuf/validation.ts
+++ b/frontend/src/utils/protobuf/validation.ts
@@ -107,13 +107,15 @@ export class ProtobufValidator {
 
   /**
    * Sanitizes an identifier (schema/messageType) by removing invalid characters.
-   * Keeps only word characters and hyphens.
-   * 
+   * Keeps word characters, hyphens, dots, and forward slashes so that
+   * fully-qualified protobuf type names (e.g. "my.package.MyMessage") and
+   * schema paths (e.g. "opentelemetry/proto/common/v1/common") survive.
+   *
    * @param identifier - The identifier to sanitize
    * @returns Sanitized identifier string
    */
   static sanitizeIdentifier(identifier: string): string {
-    return identifier.trim().replace(/[^\w\-]/g, '')
+    return identifier.trim().replace(/[^\w\-\.\/]/g, '')
   }
 
   /**


### PR DESCRIPTION
## Problem

The message **list view** displayed `Protobuf decode failed: no such type: PocOrderCreated` for every message in subjects backed by a packaged protobuf message such as `Poc.OrderCreated`, while the **detail view** decoded the same payload correctly.

### Before

<img width="3840" height="2076" alt="image" src="https://github.com/user-attachments/assets/d9de194d-f0ee-4645-b6df-c4afc7fadb0b" />

### After

<img width="3828" height="1931" alt="image" src="https://github.com/user-attachments/assets/4452d883-0441-4a2c-bdc9-040f63a74659" />


Reproducible with any `.proto` that uses a `package` declaration:

```proto
syntax = "proto3";
package Poc;
message OrderCreated {
  string order_id = 1;
  double amount = 2;
}
```

Two independent bugs combined to produce this:

### 1. `sanitizeIdentifier` stripped dots from FQNs

```ts
// frontend/src/utils/protobuf/validation.ts
return identifier.trim().replace(/[^\w\-]/g, '')
```

`\w` is `[A-Za-z0-9_]`, so any character outside word-or-hyphen — including the package separator `.` — was silently removed. After a successful auto-detect, the in-memory message type `'Poc.OrderCreated'` was passed through `validateAndSanitizeAll` before being stored in `ProtobufTopicCache`, where it became `'PocOrderCreated'`. The next list-row lookup pulled that mangled name from the cache and handed it to `schema.root.lookupType`, which fails.

The detail view re-runs full auto-detect and so never hits the bad cache entry, which is why only the list rows fail.

### 2. `ProtobufTopicCache` overwrote externally-cleared storage on unload

```ts
constructor() {
  this.load()
  window.addEventListener('beforeunload', () => this.save())
}
```

The unload handler unconditionally serialised the in-memory trie to `localStorage`. So a user trying to recover from a poisoned cache by running `localStorage.removeItem('nats-protobuf-patterns'); location.reload()` (or even `localStorage.clear()`) would have their wipe silently overwritten by the stale trie on the way out, then load that same stale trie back on the next mount.

This made the bug above effectively unrecoverable without editing storage by hand or wiping the IndexedDB / localStorage from devtools and immediately closing the tab.

## Fix

### `validation.ts`
```diff
- return identifier.trim().replace(/[^\w\-]/g, '')
+ return identifier.trim().replace(/[^\w\-\.\/]/g, '')
```

Also allows `/` through, which is needed for schema identifiers that already use slash-separated relative paths (e.g. `opentelemetry/proto/common/v1/common`). The length validators in `validateMessageType` / `validateSchema` still apply, and the remaining character class still strips whitespace, control characters and shell metacharacters.

### `ProtobufTopicCache.ts`
- Track a `dirty` flag. `save()` is now a no-op until something has actually been mutated this session. `clear()` resets the flag too.
- Add a `storage` event listener so a wipe from another tab is mirrored into in-memory state and isn't overwritten on unload.

## Tests

New `frontend/src/utils/protobuf/validation.test.ts` covers:
- Dotted FQNs round-trip through `sanitizeIdentifier`
- Slash-separated schema paths round-trip
- Underscores and hyphens preserved
- Disallowed characters still stripped
- Whitespace trimmed
- `validateAndSanitizeAll` returns the dotted message type unchanged

```
Test Files  4 passed (4)
     Tests  45 passed (45)
```

(6 new + 39 existing protobuf tests.)

## Verification

Built the patched image locally and ran against a NATS JetStream stream populated by a producer using the `Poc.OrderCreated` schema:

- **Before**: list rows red `no such type: PocOrderCreated`, detail view decoded fine.
- **After**: list rows decode to `{order_id: "A-123", amount: 42.5, ...}` from the cache hit, no manual schema selection required.

`localStorage.clear(); location.reload()` from devtools now actually clears the cache.
