### PR TITLE
Fix KV operations for keys containing slashes

### DIFF
--- a/internal/nui/kv.go
+++ b/internal/nui/kv.go
@@ -2,11 +2,10 @@ package nui
 
 import (
 	"errors"
-	"strings"
-	"time"
-
 	"github.com/gofiber/fiber/v2"
 	"github.com/nats-io/nats.go/jetstream"
+	"strings"
+	"time"
 )
 
 func kvKeyFromCtx(c *fiber.Ctx) string {

--- a/internal/nui/kv.go
+++ b/internal/nui/kv.go
@@ -2,11 +2,16 @@ package nui
 
 import (
 	"errors"
-	"github.com/gofiber/fiber/v2"
-	"github.com/nats-io/nats.go/jetstream"
 	"strings"
 	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/nats-io/nats.go/jetstream"
 )
+
+func kvKeyFromCtx(c *fiber.Ctx) string {
+	return strings.TrimPrefix(c.Params("*"), "/")
+}
 
 const KV_STREAM_PREFIX = "KV_"
 
@@ -236,7 +241,7 @@ func (a *App) HandleShowKey(c *fiber.Ctx) error {
 	if !ok {
 		return err
 	}
-	key := c.Params("key")
+	key := kvKeyFromCtx(c)
 
 	history, err := kv.History(c.Context(), key)
 	if err != nil {
@@ -264,12 +269,19 @@ type PutRequest struct {
 	TTL     time.Duration `json:"ttl,omitempty"`
 }
 
-func (a *App) HandlePutKey(c *fiber.Ctx) error {
+func (a *App) HandlePostKey(c *fiber.Ctx) error {
+	key := kvKeyFromCtx(c)
+	if strings.HasSuffix(key, "/purge") {
+		return a.handlePurgeKey(c, strings.TrimSuffix(key, "/purge"))
+	}
+	return a.handlePutKey(c, key)
+}
+
+func (a *App) handlePutKey(c *fiber.Ctx, key string) error {
 	kv, ok, err := a.bucketOrFail(c, c.Params("bucket"))
 	if !ok {
 		return err
 	}
-	key := c.Params("key")
 	if key == "" {
 		return c.Status(422).JSON("key is required")
 	}
@@ -309,7 +321,7 @@ func (a *App) HandleDeleteKey(c *fiber.Ctx) error {
 	if !ok {
 		return err
 	}
-	err = kv.Delete(c.Context(), c.Params("key"))
+	err = kv.Delete(c.Context(), kvKeyFromCtx(c))
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return a.logAndFiberError(c, err, 404)
@@ -319,12 +331,12 @@ func (a *App) HandleDeleteKey(c *fiber.Ctx) error {
 	return c.SendStatus(204)
 }
 
-func (a *App) HandlePurgeKey(c *fiber.Ctx) error {
+func (a *App) handlePurgeKey(c *fiber.Ctx, key string) error {
 	kv, ok, err := a.bucketOrFail(c, c.Params("bucket"))
 	if !ok {
 		return err
 	}
-	err = kv.Purge(c.Context(), c.Params("key"))
+	err = kv.Purge(c.Context(), key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return a.logAndFiberError(c, err, 404)

--- a/internal/nui/server.go
+++ b/internal/nui/server.go
@@ -99,10 +99,9 @@ func (a *App) registerHandlers() {
 	a.Post("/api/connection/:connection_id/kv/:bucket/purge_deleted", a.HandlePurgeDeletedKeys)
 
 	a.Get("/api/connection/:connection_id/kv/:bucket/key", a.HandleIndexKeys)
-	a.Get("/api/connection/:connection_id/kv/:bucket/key/:key", a.HandleShowKey)
-	a.Post("/api/connection/:connection_id/kv/:bucket/key/:key", a.HandlePutKey)
-	a.Delete("/api/connection/:connection_id/kv/:bucket/key/:key", a.HandleDeleteKey)
-	a.Post("/api/connection/:connection_id/kv/:bucket/key/:key/purge", a.HandlePurgeKey)
+	a.Get("/api/connection/:connection_id/kv/:bucket/key/*", a.HandleShowKey)
+	a.Post("/api/connection/:connection_id/kv/:bucket/key/*", a.HandlePostKey)
+	a.Delete("/api/connection/:connection_id/kv/:bucket/key/*", a.HandleDeleteKey)
 
 	// Proto schema read-only routes (schemas are loaded from filesystem)
 	a.Get("/api/proto", a.HandleIndexProtoSchemas)

--- a/tests/nui_test.go
+++ b/tests/nui_test.go
@@ -553,6 +553,20 @@ func (s *NuiTestSuite) TestKvEntriesRest() {
 		r = e.GET("/api/connection/" + connId + "/kv/bucket1/key/key_with_ttl").Expect()
 		assert.Equal(c, r.Raw().StatusCode, http.StatusOK)
 	}, 5*time.Second, 100*time.Millisecond)
+
+	// keys containing slashes must work (issue #129)
+	slashKey := "bar/foo"
+	r = e.POST("/api/connection/" + connId + "/kv/bucket1/key/"+slashKey).
+		WithBytes([]byte(`{"payload": "MTIz"}`)).Expect().Status(http.StatusOK)
+	r.JSON().Object().Value("key").String().IsEqual(slashKey)
+	r.JSON().Object().Value("payload").String().IsEqual("MTIz")
+
+	r = e.GET("/api/connection/" + connId + "/kv/bucket1/key/"+slashKey).Expect().Status(http.StatusOK)
+	r.JSON().Object().Value("key").String().IsEqual(slashKey)
+	r.JSON().Object().Value("payload").String().IsEqual("MTIz")
+
+	e.DELETE("/api/connection/" + connId + "/kv/bucket1/key/"+slashKey).Expect().Status(http.StatusNoContent)
+	e.POST("/api/connection/" + connId + "/kv/bucket1/key/"+slashKey+"/purge").Expect().Status(http.StatusNoContent)
 }
 
 func (s *NuiTestSuite) TestRequestResponseRest() {


### PR DESCRIPTION
Use Fiber wildcard routes for KV key endpoints so keys like bar/foo are not split across URL path segments. Dispatch POST put vs purge from a single handler and add integration coverage for slash keys.

Fixes #129

**THIS WAS ENTIRELY AI GENERATED USING GROK BUILD**

but I did manually reviewed the implementation and the tests, and built and ran the image to ensure the problem was fixed (it was)