### PR TITLE
fix(streams): list messages without a consumer to support WorkQueue/Interest streams

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -467,104 +467,6 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
-      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
-      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
-      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5",
-        "cli-width": "^4.1.0",
-        "fast-wrap-ansi": "^0.2.0",
-        "mute-stream": "^3.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -577,36 +479,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
-      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -693,26 +565,6 @@
         "events": "^3.3.0"
       }
     },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
-      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
     "node_modules/@open-draft/until": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
@@ -743,7 +595,6 @@
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/@priolo/jon/-/jon-0.7.7.tgz",
       "integrity": "sha512-jENPcKivoQmtkf1LZSgbeLYP0+7ZN8/i2zUwCbmg7628wuYWLYvvAoNUUMmmxRPZuDckklpK4l23ZWD2ZoSA8A==",
-      "peer": true,
       "dependencies": {
         "@priolo/jon-utils": "^0.4.1"
       },
@@ -1478,7 +1329,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1502,14 +1352,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.11.0",
@@ -2310,36 +2152,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/fast-string-truncated-width": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/fast-string-width": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-string-truncated-width": "^3.0.2"
-      }
-    },
-    "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-string-width": "^3.0.2"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -2949,8 +2761,7 @@
     "node_modules/monaco-editor": {
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "peer": true
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3230,7 +3041,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3242,7 +3052,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3319,14 +3128,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/rettime": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
-      "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -3516,7 +3317,6 @@
       "version": "0.114.0",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.114.0.tgz",
       "integrity": "sha512-r3KHl22433DlN5BpLAlL4b3D8ItoGKAkj91YT6GhP39XuLoBT+YFd9ObKuL/okgiPb5lbwnW+71fM45hHceN9w==",
-      "peer": true,
       "dependencies": {
         "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
@@ -3591,17 +3391,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -3683,20 +3472,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -3762,7 +3537,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3797,28 +3571,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tldts-core": "^7.0.28"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3830,20 +3582,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -3865,7 +3603,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -3898,7 +3635,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3911,17 +3647,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
-    },
-    "node_modules/until-async": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/kettanaito"
-      }
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -3950,7 +3675,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4062,7 +3786,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4142,41 +3865,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@mswjs/interceptors": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
-      "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/vitest/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
@@ -4203,33 +3891,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/vitest/node_modules/headers-polyfill": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
-      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.10",
-        "set-cookie-parser": "^3.0.1"
-      }
-    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -4241,39 +3902,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest/node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/vitest/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/vitest/node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/wcwidth": {

--- a/internal/nui/streams.go
+++ b/internal/nui/streams.go
@@ -3,9 +3,7 @@ package nui
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/nats-nui/nui/internal/ws"
 	"strconv"
@@ -214,105 +212,233 @@ func (a *App) HandleIndexStreamMessages(c *fiber.Ctx) error {
 		return c.JSON([]ws.NatsMsg{})
 	}
 
-	// Stream has messages, ,so proceed with consumer configuration based on query parameters
-	config := jetstream.ConsumerConfig{
-		DeliverPolicy: jetstream.DeliverByStartSequencePolicy,
-		MemoryStorage: true,
-		Name:          "nui-" + uuid.NewString(),
+	// Subjects to filter on. An empty filter matches every subject (">").
+	subjects := strings.Split(c.Query("subjects"), ",")
+	if len(subjects) == 0 || subjects[0] == "" {
+		subjects = []string{">"}
 	}
 
-	subjects := strings.Split(c.Query("subjects"), ",")
-	if len(subjects) > 0 && subjects[0] != "" {
-		if len(subjects) == 1 {
-			config.FilterSubject = subjects[0]
-		} else {
-			config.FilterSubjects = subjects
-		}
-	}
+	// interval is the number of messages to return. A negative value walks
+	// backwards, returning the |interval| messages ending at the start position.
 	interval, err := strconv.Atoi(c.Query("interval"))
 	if err != nil {
 		interval = 25
 	}
-	// batch is the absolute value of the interval
-	batch := interval
-	if batch < 0 {
-		batch = -batch
+	limit := interval
+	if limit < 0 {
+		limit = -limit
+	}
+	if limit == 0 {
+		return c.JSON([]ws.NatsMsg{})
 	}
 
-	var msgCount int
-	msgs := make([]ws.NatsMsg, 0, batch)
-
-	timeStr := c.Query("start_time")
-	if timeStr != "" {
-		config.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+	// Messages are read directly from the stream through the Get Message API
+	// (Stream.GetMsg), so no consumer is created. This is what allows browsing
+	// WorkQueue and Interest streams, where extra or overlapping consumers are
+	// forbidden by the server.
+	var raw []*jetstream.RawStreamMsg
+	if timeStr := c.Query("start_time"); timeStr != "" {
 		t, err := time.Parse(time.RFC3339, timeStr)
 		if err != nil {
 			return a.logAndFiberError(c, err, 422)
 		}
-		config.OptStartTime = &t
-		msgCount = batch
-	} else {
-		querySeq, err := strconv.Atoi(c.Query("seq_start"))
-		if err != nil {
-			info, err := stream.Info(c.Context())
-			if err != nil {
-				return a.logAndFiberError(c, err, 500)
-			}
-			if interval > 0 {
-				querySeq = int(info.State.FirstSeq)
-			} else {
-				querySeq = int(info.State.LastSeq)
-			}
-			querySeq = max(querySeq, 1)
-		}
-		var seekFromSeq uint64
-		seekFromSeq, msgCount, err = findSeekSeq(c.Context(), stream, info, config, querySeq, interval)
+		startSeq, found, err := findSeqByTime(c.Context(), stream, info, t)
 		if err != nil {
 			return a.logAndFiberError(c, err, 500)
 		}
-		if msgCount == 0 {
-			return c.JSON(msgs)
+		if !found {
+			return c.JSON([]ws.NatsMsg{})
 		}
-		config.OptStartSeq = seekFromSeq
+		raw, err = collectForward(c.Context(), stream, startSeq, subjects, 0, limit)
+		if err != nil {
+			return a.logAndFiberError(c, err, 500)
+		}
+		return c.JSON(toNatsMsgs(raw))
 	}
 
-	msgs, err = a.fetchMessages(c, err, stream, config, batch, msgs, msgCount)
+	querySeq, err := strconv.Atoi(c.Query("seq_start"))
+	if err != nil {
+		if interval > 0 {
+			querySeq = int(info.State.FirstSeq)
+		} else {
+			querySeq = int(info.State.LastSeq)
+		}
+	}
+	querySeq = max(querySeq, 1)
+
+	if interval > 0 {
+		raw, err = collectForward(c.Context(), stream, uint64(querySeq), subjects, 0, limit)
+	} else {
+		raw, err = collectBackward(c.Context(), stream, info, uint64(querySeq), subjects, limit)
+	}
 	if err != nil {
 		return a.logAndFiberError(c, err, 500)
 	}
-	return c.JSON(msgs)
+	return c.JSON(toNatsMsgs(raw))
 }
 
-func (a *App) fetchMessages(c *fiber.Ctx, err error, stream jetstream.Stream, config jetstream.ConsumerConfig, batch int, msgs []ws.NatsMsg, msgCount int) ([]ws.NatsMsg, error) {
-	consumer, err := stream.CreateOrUpdateConsumer(c.Context(), config)
-	if err != nil {
-		return nil, err
+// getNextMsg fetches the first message with a sequence >= fromSeq whose subject
+// matches subject (which may be a wildcard such as ">"). It relies on
+// Stream.GetMsg, which reads directly from the stream and creates no consumer,
+// so it works on any stream regardless of its retention policy. found is false
+// when no matching message exists at or after fromSeq.
+func getNextMsg(ctx context.Context, stream jetstream.Stream, fromSeq uint64, subject string) (*jetstream.RawStreamMsg, bool, error) {
+	if fromSeq < 1 {
+		fromSeq = 1
 	}
-	msgBatch, err := consumer.FetchNoWait(batch)
+	msg, err := stream.GetMsg(ctx, fromSeq, jetstream.WithGetMsgSubject(subject))
 	if err != nil {
-		return nil, err
+		if errors.Is(err, jetstream.ErrMsgNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
 	}
-	for msg := range msgBatch.Messages() {
-		if len(msgs) == msgCount {
+	return msg, true, nil
+}
+
+// collectForward returns messages matching one of subjects, in ascending
+// sequence order, starting at startSeq. When maxSeq > 0, messages beyond maxSeq
+// are excluded. When limit > 0, at most limit messages are returned. Gaps left
+// by deleted or expired messages are skipped naturally, since GetMsg jumps to
+// the next existing message. Each subject is only re-queried once its cached
+// candidate is consumed, so a single-subject browse costs one request per
+// returned message.
+func collectForward(ctx context.Context, stream jetstream.Stream, startSeq uint64, subjects []string, maxSeq uint64, limit int) ([]*jetstream.RawStreamMsg, error) {
+	msgs := make([]*jetstream.RawStreamMsg, 0, limit)
+	cursor := startSeq
+	if cursor < 1 {
+		cursor = 1
+	}
+	candidates := make(map[string]*jetstream.RawStreamMsg, len(subjects))
+	exhausted := make(map[string]bool, len(subjects))
+	for {
+		if limit > 0 && len(msgs) >= limit {
 			break
 		}
-		if msgBatch.Error() != nil {
-			return nil, fmt.Errorf("failed to fetch message: %w", msgBatch.Error())
+		var best *jetstream.RawStreamMsg
+		for _, subject := range subjects {
+			if exhausted[subject] {
+				continue
+			}
+			cand := candidates[subject]
+			if cand == nil || cand.Sequence < cursor {
+				m, found, err := getNextMsg(ctx, stream, cursor, subject)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					exhausted[subject] = true
+					delete(candidates, subject)
+					continue
+				}
+				cand = m
+				candidates[subject] = m
+			}
+			if best == nil || cand.Sequence < best.Sequence {
+				best = cand
+			}
 		}
-		metadata, err := msg.Metadata()
+		if best == nil {
+			break
+		}
+		if maxSeq > 0 && best.Sequence > maxSeq {
+			break
+		}
+		msgs = append(msgs, best)
+		cursor = best.Sequence + 1
+	}
+	return msgs, nil
+}
+
+// collectBackward returns up to limit messages matching one of subjects whose
+// sequence is <= startSeq, in ascending order (the tail of the match set). It
+// scans forward inside a window that grows until enough matches are found or the
+// beginning of the stream is reached, so it needs no consumer while still
+// honouring gaps and subject filters.
+func collectBackward(ctx context.Context, stream jetstream.Stream, info *jetstream.StreamInfo, startSeq uint64, subjects []string, limit int) ([]*jetstream.RawStreamMsg, error) {
+	firstSeq := info.State.FirstSeq
+	if startSeq < firstSeq {
+		return []*jetstream.RawStreamMsg{}, nil
+	}
+	upper := startSeq
+	if lastSeq := info.State.LastSeq; upper > lastSeq {
+		upper = lastSeq
+	}
+	window := uint64(limit)
+	for {
+		lo := firstSeq
+		if upper+1 > window {
+			if cand := upper + 1 - window; cand > firstSeq {
+				lo = cand
+			}
+		}
+		msgs, err := collectForward(ctx, stream, lo, subjects, upper, 0)
 		if err != nil {
 			return nil, err
 		}
+		if len(msgs) >= limit {
+			return msgs[len(msgs)-limit:], nil
+		}
+		if lo == firstSeq {
+			return msgs, nil
+		}
+		window *= 2
+	}
+}
+
+// findSeqByTime returns the sequence of the first message whose timestamp is at
+// or after t, using a binary search over the stream sequences (message
+// timestamps are monotonic with sequence). found is false when every message
+// predates t. It reads messages directly and creates no consumer.
+func findSeqByTime(ctx context.Context, stream jetstream.Stream, info *jetstream.StreamInfo, t time.Time) (uint64, bool, error) {
+	lo, hi := info.State.FirstSeq, info.State.LastSeq
+	if hi < lo {
+		return 0, false, nil
+	}
+	var result uint64
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		msg, found, err := getNextMsg(ctx, stream, mid, ">")
+		if err != nil {
+			return 0, false, err
+		}
+		if !found {
+			// No message exists at or after mid, so any match is lower.
+			if mid == 0 {
+				break
+			}
+			hi = mid - 1
+			continue
+		}
+		if msg.Time.Before(t) {
+			lo = msg.Sequence + 1
+			continue
+		}
+		// This message is a match; look for an earlier one below mid.
+		result = msg.Sequence
+		if mid == 0 {
+			break
+		}
+		hi = mid - 1
+	}
+	if result == 0 {
+		return 0, false, nil
+	}
+	return result, true, nil
+}
+
+func toNatsMsgs(raw []*jetstream.RawStreamMsg) []ws.NatsMsg {
+	msgs := make([]ws.NatsMsg, 0, len(raw))
+	for _, m := range raw {
 		msgs = append(msgs, ws.NatsMsg{
-			Subject:    msg.Subject(),
-			SeqNum:     metadata.Sequence.Stream,
-			ReceivedAt: metadata.Timestamp,
-			Payload:    msg.Data(),
-			Headers:    msg.Headers(),
+			Subject:    m.Subject,
+			SeqNum:     m.Sequence,
+			ReceivedAt: m.Time,
+			Payload:    m.Data,
+			Headers:    m.Header,
 		})
 	}
-	_ = stream.DeleteConsumer(c.Context(), config.Name)
-	return msgs, nil
+	return msgs
 }
 
 func (a *App) HandleDeleteStreamMessage(c *fiber.Ctx) error {
@@ -343,72 +469,4 @@ func (a *App) HandleDeleteStreamMessage(c *fiber.Ctx) error {
 		return a.logAndFiberError(c, err, 500)
 	}
 	return c.SendStatus(200)
-}
-
-func findSeekSeq(ctx context.Context, stream jetstream.Stream, info *jetstream.StreamInfo, consumerConfig jetstream.ConsumerConfig, startSeq int, interval int) (uint64, int, error) {
-	if interval >= 0 {
-		return uint64(startSeq), interval, nil
-	}
-
-	if uint64(startSeq) < info.State.FirstSeq {
-		return info.State.FirstSeq, 0, nil
-	}
-	intervalMultiplier := 1
-	firstSeq := startSeq
-	for {
-		batch := min(10000, -interval*intervalMultiplier)
-		firstSeq -= batch - 1
-		if firstSeq <= 1 || uint64(firstSeq) <= info.State.FirstSeq {
-			return info.State.FirstSeq, int(info.State.FirstSeq - uint64(firstSeq)), nil
-		}
-		if uint64(firstSeq) == info.State.FirstSeq {
-			return info.State.FirstSeq, 1, nil
-		}
-		consumerConfig.OptStartSeq = uint64(firstSeq)
-		consumerConfig.HeadersOnly = true
-		consumer, err := stream.CreateConsumer(ctx, consumerConfig)
-		if err != nil {
-			return 0, 0, err
-		}
-		msgBatch, err := consumer.FetchNoWait(batch)
-		if err != nil {
-			return 0, 0, err
-		}
-		neededSeq, msgsCount, done, err := findSeqInBatch(msgBatch, startSeq, batch)
-		err = stream.DeleteConsumer(context.Background(), consumerConfig.Name)
-		if err != nil {
-			jsErr, ok := err.(jetstream.JetStreamError)
-			if !ok || jsErr.APIError().Code != 404 {
-				return 0, 0, nil
-			}
-		}
-		if done {
-			return neededSeq, msgsCount, nil
-		}
-	}
-}
-
-func findSeqInBatch(msgBatch jetstream.MessageBatch, startSeq int, batch int) (uint64, int, bool, error) {
-	neededSeq := uint64(0)
-	msgsCount := 0
-	for msg := range msgBatch.Messages() {
-		if msgBatch.Error() != nil {
-			return 0, 0, false, msgBatch.Error()
-		}
-		msgsCount++
-		metadata, err := msg.Metadata()
-		if err != nil {
-			return 0, 0, false, err
-		}
-		if neededSeq == 0 {
-			neededSeq = metadata.Sequence.Stream
-		}
-		if metadata.Sequence.Stream > uint64(startSeq) {
-			return 0, 0, false, nil
-		}
-		if msgsCount >= batch {
-			return neededSeq, msgsCount, true, nil
-		}
-	}
-	return 0, 0, false, nil
 }

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"fmt"
-	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/jetstream"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 // newConnection creates a new connection with the given JSON payload.
@@ -72,6 +74,54 @@ func (s *NuiTestSuite) emptyStream(name string, subjects ...string) (jetstream.S
 	return stream, err
 }
 
+func (s *NuiTestSuite) publishSubjects(subjects ...string) {
+	for _, subject := range subjects {
+		_, err := s.js.Publish(s.ctx, subject, []byte(subject))
+		s.NoError(err)
+	}
+}
+
+func (s *NuiTestSuite) publishN(subject string, n int) {
+	for i := 0; i < n; i++ {
+		_, err := s.js.Publish(s.ctx, subject, []byte(subject))
+		s.NoError(err)
+	}
+}
+
+func (s *NuiTestSuite) deleteSeqs(streamName string, seqs ...uint64) {
+	stream, err := s.js.Stream(s.ctx, streamName)
+	s.NoError(err)
+	for _, seq := range seqs {
+		s.NoError(stream.DeleteMsg(s.ctx, seq))
+	}
+}
+
+func (s *NuiTestSuite) deleteSeqRange(streamName string, from, to uint64) {
+	stream, err := s.js.Stream(s.ctx, streamName)
+	s.Require().NoError(err)
+	s.Require().NotNil(stream)
+	for seq := from; seq <= to; seq++ {
+		s.NoError(stream.DeleteMsg(s.ctx, seq))
+	}
+}
+
+func messageSeqs(arr *httpexpect.Array) []uint64 {
+	n := int(arr.Length().Raw())
+	out := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		out[i] = uint64(arr.Value(i).Object().Value("seq_num").Number().Raw())
+	}
+	return out
+}
+
+func (s *NuiTestSuite) streamMessages(connId, stream, query string) *httpexpect.Array {
+	req := s.e.GET("/api/connection/" + connId + "/stream/" + stream + "/messages")
+	if query != "" {
+		req = req.WithQueryString(query)
+	}
+	return req.Expect().Status(http.StatusOK).JSON().Array()
+}
+
 func (s *NuiTestSuite) filledKvs(name string) jetstream.KeyValue {
 	kv := s.emptyKvs(name)
 	for i := 1; i <= 10; i++ {
@@ -97,6 +147,6 @@ func (s *NuiTestSuite) emptyKvs(name string) jetstream.KeyValue {
 
 func (s *NuiTestSuite) ensureNoNuiConsumersPending(connId, stream string) {
 	time.Sleep(200 * time.Millisecond)
-	s.e.GET("/api/connection/" + connId + "/stream/stream1/consumer").
+	s.e.GET("/api/connection/" + connId + "/stream/" + stream + "/consumer").
 		Expect().Status(http.StatusOK).JSON().Array().Length().IsEqual(0)
 }

--- a/tests/nui_test.go
+++ b/tests/nui_test.go
@@ -424,6 +424,59 @@ func (s *NuiTestSuite) TestStreamMessagesIndexWithNegativeInterval() {
 
 }
 
+func (s *NuiTestSuite) TestStreamMessagesIndexOnWorkQueueStream() {
+	e := s.e
+	connId := s.defaultConn()
+
+	// A WorkQueue stream only allows a single, non-overlapping consumer per
+	// subject. NUI must therefore read messages directly from the stream
+	// instead of creating a consumer, otherwise listing fails with
+	// "multiple non-filtered consumers not allowed on workqueue stream".
+	stream, err := s.js.CreateStream(s.ctx, jetstream.StreamConfig{
+		Name:      "wq_stream",
+		Subjects:  []string{"wq.>"},
+		Storage:   jetstream.MemoryStorage,
+		Retention: jetstream.WorkQueuePolicy,
+	})
+	s.NoError(err)
+	for i := 1; i <= 10; i++ {
+		_, err = s.js.Publish(s.ctx, "wq.high", []byte(fmt.Sprintf("msg%d", i)))
+		s.NoError(err)
+	}
+
+	// Simulate a worker already bound to the subject: this is exactly what made
+	// the previous consumer-based listing fail.
+	_, err = stream.CreateOrUpdateConsumer(s.ctx, jetstream.ConsumerConfig{
+		Durable:       "worker",
+		FilterSubject: "wq.high",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	s.NoError(err)
+
+	// Listing all messages works without disturbing the worker.
+	r := e.GET("/api/connection/" + connId + "/stream/wq_stream/messages").
+		Expect().Status(http.StatusOK).JSON().Array()
+	r.Length().IsEqual(10)
+	r.Value(0).Object().Value("seq_num").IsEqual(1)
+	r.Value(0).Object().Value("payload").NotEqual("")
+
+	// Filtering by the very subject the worker consumes also works.
+	e.GET("/api/connection/" + connId + "/stream/wq_stream/messages").
+		WithQueryString("subjects=wq.high").
+		Expect().Status(http.StatusOK).JSON().Array().Length().IsEqual(10)
+
+	// Negative interval (used to load older messages) works too.
+	rNeg := e.GET("/api/connection/" + connId + "/stream/wq_stream/messages").
+		WithQueryString("interval=-3").
+		Expect().Status(http.StatusOK).JSON().Array()
+	rNeg.Length().IsEqual(3)
+	rNeg.Value(0).Object().Value("seq_num").IsEqual(8)
+
+	// The worker consumer is still present and untouched.
+	e.GET("/api/connection/" + connId + "/stream/wq_stream/consumer").
+		Expect().Status(http.StatusOK).JSON().Array().Length().IsEqual(1)
+}
+
 func (s *NuiTestSuite) TestStreamMessagesWithStartTime() {
 	e := s.e
 	connId := s.defaultConn()

--- a/tests/nui_test.go
+++ b/tests/nui_test.go
@@ -495,6 +495,70 @@ func (s *NuiTestSuite) TestStreamMessagesWithStartTime() {
 	r.Value(1).Object().Value("payload").String().IsEqual("bXNnMg==")
 }
 
+func (s *NuiTestSuite) TestStreamMessagesIndexAdvanced() {
+	connId := s.defaultConn()
+
+	// Merge: interleaved subjects, filter merge.a + merge.c.
+	// seq 1 merge.a, 2 merge.b, 3 merge.c, 4 merge.a, 5 merge.b, 6 merge.c
+	s.emptyStream("merge_stream", "merge.a", "merge.b", "merge.c")
+	s.publishSubjects("merge.a", "merge.b", "merge.c", "merge.a", "merge.b", "merge.c")
+	s.Equal([]uint64{1, 3, 4, 6}, messageSeqs(s.streamMessages(connId, "merge_stream", "subjects=merge.a,merge.c")))
+	s.ensureNoNuiConsumersPending(connId, "merge_stream")
+
+	// Holes: seq_start on a deleted sequence jumps to the next existing message.
+	// seq 1-10, delete 4, 5, 6 → remaining 1, 2, 3, 7, 8, 9, 10
+	s.emptyStream("hole_stream", "hole.events")
+	s.publishN("hole.events", 10)
+	s.deleteSeqs("hole_stream", 4, 5, 6)
+	s.Equal([]uint64{7, 8, 9}, messageSeqs(s.streamMessages(connId, "hole_stream", "seq_start=4&interval=3")))
+	s.ensureNoNuiConsumersPending(connId, "hole_stream")
+
+	// Sparse backward: keep only at the ends, noise in between.
+	// seq 1 sparse.keep, 2-21 sparse.noise, 22 sparse.keep
+	// interval=-2 must grow the window past 20 noise messages to return both keeps.
+	s.emptyStream("sparse_stream", "sparse.keep", "sparse.noise")
+	s.publishSubjects("sparse.keep")
+	s.publishN("sparse.noise", 20)
+	s.publishSubjects("sparse.keep")
+	s.Equal([]uint64{1, 22}, messageSeqs(s.streamMessages(connId, "sparse_stream", "subjects=sparse.keep&interval=-2")))
+	s.ensureNoNuiConsumersPending(connId, "sparse_stream")
+
+	// Pagination: 9 messages, pages of 3 (UI fetchNext / fetchPrev).
+	s.emptyStream("page_stream", "page.events")
+	s.publishN("page.events", 9)
+	s.Equal([]uint64{1, 2, 3}, messageSeqs(s.streamMessages(connId, "page_stream", "seq_start=1&interval=3")))
+	s.Equal([]uint64{4, 5, 6}, messageSeqs(s.streamMessages(connId, "page_stream", "seq_start=4&interval=3")))
+	s.Equal([]uint64{1, 2, 3}, messageSeqs(s.streamMessages(connId, "page_stream", "seq_start=3&interval=-3")))
+	s.Equal([]uint64{7, 8, 9}, messageSeqs(s.streamMessages(connId, "page_stream", "interval=-3")))
+	s.ensureNoNuiConsumersPending(connId, "page_stream")
+
+	// start_time edges on a 3-message stream (no sleep needed: times are ±1h).
+	s.emptyStream("time_stream", "time.events")
+	s.publishN("time.events", 3)
+	before := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	after := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	s.Equal([]uint64{1, 2, 3}, messageSeqs(s.streamMessages(connId, "time_stream", "start_time="+before+"&interval=3")))
+	s.streamMessages(connId, "time_stream", "start_time="+after).Length().IsEqual(0)
+	s.e.GET("/api/connection/"+connId+"/stream/time_stream/messages").
+		WithQuery("start_time", "not-a-time").
+		Expect().Status(http.StatusUnprocessableEntity)
+	s.streamMessages(connId, "time_stream", "interval=0").Length().IsEqual(0)
+	s.streamMessages(connId, "time_stream", "seq_start=100&interval=5").Length().IsEqual(0)
+	s.ensureNoNuiConsumersPending(connId, "time_stream")
+
+	// Binary search by start_time on a large stream with a hole around the midpoint.
+	// 200 messages; delete 80-120 so GetMsg at mid (seq 100) lands in the hole.
+	// Time boundary is after seq 100: first remaining message at/after that time is 121.
+	s.emptyStream("seek_stream", "seek.events")
+	s.publishN("seek.events", 100)
+	time.Sleep(1100 * time.Millisecond)
+	gap := time.Now().UTC().Format(time.RFC3339)
+	s.publishN("seek.events", 100)
+	s.deleteSeqRange("seek_stream", 80, 120)
+	s.Equal([]uint64{121, 122, 123}, messageSeqs(s.streamMessages(connId, "seek_stream", "start_time="+gap+"&interval=3")))
+	s.ensureNoNuiConsumersPending(connId, "seek_stream")
+}
+
 func (s *NuiTestSuite) TestStreamMessagesDelete() {
 	e := s.e
 	connId := s.defaultConn()


### PR DESCRIPTION
closes #58 #95

This pull request significantly refactors how stream messages are listed in the `nui` package to avoid creating consumers, which is necessary for compatibility with WorkQueue and Interest streams. Instead, messages are now fetched directly from the stream using the Get Message API. The code is simplified, and new helper functions are introduced for efficient forward and backward message retrieval. Comprehensive tests are added to ensure the new approach works with WorkQueue streams, including scenarios with existing consumers.

**Stream message listing refactor:**

* Refactored `HandleIndexStreamMessages` in `internal/nui/streams.go` to fetch messages directly from the stream using `GetMsg`, eliminating the need to create consumers and ensuring compatibility with WorkQueue and Interest streams. Introduced new helper functions: `getNextMsg`, `collectForward`, `collectBackward`, `findSeqByTime`, and `toNatsMsgs`.
* Removed legacy consumer-based message fetching logic and associated helper functions (`fetchMessages`, `findSeekSeq`, `findSeqInBatch`).
* Cleaned up unused imports (`fmt`, `github.com/google/uuid`) from `internal/nui/streams.go`.

**Testing improvements:**

* Added `TestStreamMessagesIndexOnWorkQueueStream` to `tests/nui_test.go` to verify that message listing works on WorkQueue streams without interfering with existing consumers, and that subject filtering and negative intervals are handled correctly.